### PR TITLE
Make readAllBytesIfFileExists a derived operation

### DIFF
--- a/src/main/scala/org/mdoc/fshell/ShellCompanion.scala
+++ b/src/main/scala/org/mdoc/fshell/ShellCompanion.scala
@@ -35,9 +35,6 @@ object ShellCompanion {
   def readAllBytes(path: Path): Shell[ByteVector] =
     Free.liftFC(ShellOp.ReadAllBytes(path))
 
-  def readAllBytesIfFileExists(path: Path): Shell[Option[ByteVector]] =
-    Free.liftFC(ShellOp.ReadAllBytesIfFileExists(path))
-
   def readProcess(command: NonEmptyList[String]): Shell[ProcessResult] =
     Free.liftFC(ShellOp.ReadProcess(command, None))
 
@@ -57,6 +54,11 @@ object ShellCompanion {
 
   def fileNotExists(path: Path): Shell[Boolean] =
     fileExists(path).map(!_)
+
+  def readAllBytesIfFileExists(path: Path): Shell[Option[ByteVector]] =
+    fileExists(path).flatMap { exists =>
+      if (exists) readAllBytes(path).map(Some(_)) else Free.point(None)
+    }
 
   def writeToTempFile(prefix: String, suffix: String, bytes: ByteVector): Shell[Path] =
     createTempFile(prefix, suffix).flatMap(path => write(path, bytes).map(_ => path))

--- a/src/main/scala/org/mdoc/fshell/ShellOp.scala
+++ b/src/main/scala/org/mdoc/fshell/ShellOp.scala
@@ -19,7 +19,6 @@ object ShellOp {
   case class FileExists(path: Path) extends ShellOp[Boolean]
   case class IsDirectory(path: Path) extends ShellOp[Boolean]
   case class ReadAllBytes(path: Path) extends ShellOp[ByteVector]
-  case class ReadAllBytesIfFileExists(path: Path) extends ShellOp[Option[ByteVector]]
   case class ReadProcess(command: NonEmptyList[String], workingDir: Option[Path]) extends ShellOp[ProcessResult]
   case class Write(path: Path, bytes: ByteVector) extends ShellOp[Unit]
 
@@ -50,9 +49,6 @@ object ShellOp {
 
           case ReadAllBytes(path) =>
             Task.delay(ByteVector.view(Files.readAllBytes(path)))
-
-          case ReadAllBytesIfFileExists(path) =>
-            Task.delay(if (Files.exists(path)) Some(ByteVector.view(Files.readAllBytes(path))) else None)
 
           case ReadProcess(command, dir) => Task.delay {
             def appendTo(sb: StringBuilder)(line: String): Unit = {


### PR DESCRIPTION
Dies macht aus `readBytesIfFileExists` eine abgeleitete Operation. Siehe #2.
